### PR TITLE
Add support for visualizing spatially resolved data provided as an array

### DIFF
--- a/docs/api/Data.md
+++ b/docs/api/Data.md
@@ -38,7 +38,7 @@ The data set to visualize. The input must be one of the following types:
 
 #### np_atoms
 
-*Type:* `list` *(Required only if data is of type `numpy.ndarray`)*
+*Type:* `list` *(Required only if data is of type `numpy.ndarray` and `'atom'` is not included in the plot's [`MolecularDataProperties`](./Properties.md#MolecularDataProperties) `columns` list and input data)*
 
 A list of atom names corresponding to each row in the provided 2D array. Other molecular data formats will contain this data by default, but when using arrays to pass in data it must be explicitly stated. For example, for the sample data passed in above, the passed in list of atoms would look like the following:
 
@@ -57,16 +57,18 @@ An [ASE cell](https://wiki.fysik.dtu.dk/ase/ase/cell.html) object representing t
 ### Initializer
 
 ```python
-el.SpatiallyResolvedData(data: Union[str, numpy.ndarry], grid_points: list, grid_spacing: list)
+el.SpatiallyResolvedData(data: Union[str, numpy.ndarry], grid_points: list, grid_spacing: list, np_atoms: list, ase_cell: cell)
 ```
 
 ### Parameters
 
-| **Name**     | **Type**                | **Description**                                                       |
-| ------------ | ----------------------- | --------------------------------------------------------------------- |
-| data         | `str` or `numpy.ndarry` | Spatially resolved data set to visualize                              |
-| grid_points  | `list`                  | `[x, y, z]` list of the number of grid points in each direction       |
-| grid_spacing | `list`                  | `[x, y, z]` list of the spacing between grid points in each direction |
+| **Name**     | **Type**                | **Description**                                                               |
+| ------------ | ----------------------- | ----------------------------------------------------------------------------- |
+| data         | `str` or `numpy.ndarry` | Spatially resolved data set to visualize                                      |
+| grid_points  | `list`                  | `[x, y, z]` list of the number of grid points in each direction               |
+| grid_spacing | `list`                  | `[x, y, z]` list of the spacing between grid points in each direction         |
+| np_atoms     | `list`                  | List of atom names for each row of data if 2D numpy array is passed into data |
+| ase_cell     | ASE `cell`              | ASE cell object provided if data is passed in as a numpy array                |
 
 #### data
 
@@ -89,3 +91,19 @@ The data set to visualize. The input must be one of the following types:
 *Type:* `list` *(Optional)*
 
 `[x, y, z]` list of the spacing between grid points in each direction
+
+#### np_atoms
+
+*Type:* `list` *(Required only if data is of type `numpy.ndarray` and `'atom'` is not included in the plot's [`SpatiallyResolvedDataProperties`](./Properties.md#SpatiallyResolvedDataProperties) `columns` list and input data)*
+
+A list of atom names corresponding to each row in the provided 2D array. Other molecular data formats will contain this data by default, but when using arrays to pass in data it must be explicitly stated. For example, for the sample data passed in above, the passed in list of atoms would look like the following:
+
+```python
+atoms = ['Fe', 'Fe']
+```
+
+#### ase_cell
+
+*Type:* `cell` *(Required only if data is of type `numpy.ndarray`)*
+
+An [ASE cell](https://wiki.fysik.dtu.dk/ase/ase/cell.html) object representing three lattice vectors forming a parallelepiped.

--- a/electrolens/plot.py
+++ b/electrolens/plot.py
@@ -50,7 +50,13 @@ class SpatiallyResolvedDataProperties(object):
 
         Returns: None
         """
-        configuration['spatiallyResolvedPropertyList'] = self.columns
+        # add 'atom' to list of properties in JSON config if not already present in the columns list
+        # create a copy of the list so 'atom' does not get added to self.columns
+        cols_copy = self.columns.copy()
+        if 'atom' not in cols_copy:
+            cols_copy.append('atom')
+        configuration['spatiallyResolvedPropertyList'] = cols_copy
+
         configuration['pointcloudDensity'] = self.density_property
         configuration['densityCutoffLow'] = self.density_lower_limit
         configuration['densityCutoffUp'] = self.density_upper_limit
@@ -84,7 +90,12 @@ class MolecularDataProperties(object):
 
         Returns: None
         """
-        configuration['moleculePropertyList'] = self.columns
+        # add 'atom' to list of properties in JSON config if not already present in the columns list
+        # create a copy of the list so 'atom' does not get added to self.columns
+        cols_copy = self.columns.copy()
+        if 'atom' not in cols_copy:
+            cols_copy.append('atom')
+        configuration['moleculePropertyList'] = cols_copy
 
 
 class FramedDataProperties(object):

--- a/electrolens/view.py
+++ b/electrolens/view.py
@@ -18,7 +18,9 @@ class SpatiallyResolvedData(object):
     def __init__(self,
                  data: Union[str, np.ndarray],
                  grid_points: list = None,
-                 grid_spacing: list = None):
+                 grid_spacing: list = None,
+                 np_atoms: List[str] = None,
+                 ase_cell: cell = None):
         """
         initializes spatially resolved data
         Args:
@@ -29,6 +31,8 @@ class SpatiallyResolvedData(object):
         self.data = data
         self.grid_points = grid_points
         self.grid_spacing = grid_spacing
+        self.np_atoms = np_atoms
+        self.ase_cell = ase_cell
 
     def add_configuration(self,
                           configuration: dict,
@@ -45,6 +49,10 @@ class SpatiallyResolvedData(object):
 
         Returns: None
         """
+        # add additional properties for numpy array
+        ExtraProperties = namedtuple('ExtraProperties', ['np_atoms', 'cell'])
+        extra_properties = ExtraProperties(np_atoms=self.np_atoms, cell=self.ase_cell)
+
         # create converter
         converter = Converter.create_converter(data=self.data, target_format=DataFormat.SPATIALLY_RESOLVED_DATA)
 
@@ -53,14 +61,17 @@ class SpatiallyResolvedData(object):
             with open(data_output_file, mode='w', newline='') as file:
                 converter.convert(output=configuration,
                                   properties=properties,
+                                  extra_properties=extra_properties,
                                   framed_properties=framed_properties,
                                   data_output_file=file)
         else:
             converter.convert(output=configuration,
                               properties=properties,
+                              extra_properties=extra_properties,
                               framed_properties=framed_properties)
 
         # grid points
+        configuration['spatiallyResolvedData'] = {}
         srd_config = configuration['spatiallyResolvedData']
         if self.grid_points is not None:
             srd_config['numGridPoints'] = {

--- a/examples/spatially_resolved_array.py
+++ b/examples/spatially_resolved_array.py
@@ -1,0 +1,32 @@
+"""
+electrolens example to plot spatially resolved data from a file
+"""
+import electrolens as el
+import numpy as np
+from ase import cell
+
+# create electrolens plot
+spatially_resolved_properties = el.SpatiallyResolvedDataProperties(
+    columns=['x', 'y', 'z', 'rho', 'gamma', 'epxc', 'deriv1', 'deriv2', 'atom'],
+    density_property='rho', density_lower_limit=0.00001, density_upper_limit=1000000)
+
+plot = el.Plot(spatially_resolved_properties=spatially_resolved_properties)
+
+# data setup
+atoms = ['Fe', 'Fe']
+data = np.array([[2.96673, 2.64244, 5.63191, 1, 1, 1, 1, 1, 'Fe'], [1, 2.64159, 5.63251, 2, 2, 2, 2, 2, 'Fe']])
+cell = cell.Cell([[0.0, 2.04, 2.04], [2.04, 0.0, 2.04], [2.04, 2.04, 0.0]])
+
+# create 3D view and add data to it
+view = el.ThreeDView(system_name='C6H6')
+spatially_resolved_data = el.SpatiallyResolvedData(data=data, np_atoms=atoms, ase_cell=cell, grid_points=[30, 30, 30],
+                                                   grid_spacing=[0.4, 0.3, 0.3])
+view.add_data(spatially_resolved_data, output_data_file='spat_data.csv')
+
+# add view to the plot
+plot.add_view(view)
+
+# show plot
+#plot.show()
+
+plot.save_configuration('spat_resolved_config.json')


### PR DESCRIPTION
1. Since molecular array data and spatially resolved data come in exactly the same type and have the same structure except for the actual column names themselves, I combined these two data types into a single converter called `ArrayToAnyDataConverter`. This converter supports both molecular and spatially resolved data passed in as an array.
2. Added two new fields to the `SpatiallyResolvedData` constructor: `np_atoms` and `ase_cell`, which serve the same purpose as their counterparts in `MolecularData`. 
3. Updated the docs to reflect the new user interface.